### PR TITLE
Add basic image upload interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-public
 .cache

--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ Nous utilisons `import { exec } from 'child_process';` dans notre fichier `gulpf
 2. Explorez d'autres outils ou plugins d'optimisation d'images qui sont compatibles avec votre environnement de projet.
 
 Ces solutions peuvent aider à surmonter les problèmes de compatibilité potentiels avec l'usage du format ESM.
+
+## Interface web
+
+Un petit serveur Express permet de téléverser des images et de les convertir directement depuis le navigateur. Démarrez-le avec :
+
+```bash
+node server.mjs
+```
+
+Ouvrez ensuite [http://localhost:3000](http://localhost:3000) pour accéder à la page de glisser‑déposer. Choisissez le format et la taille souhaités puis cliquez sur **Optimiser**. Les images traitées apparaissent plus bas avec un lien de téléchargement.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "gulp-webp": "^4.0.1",
         "imagemin-webp": "^8.0.0",
         "p-map": "^6.0.0",
-        "sharp": "^0.32.2"
+        "sharp": "^0.32.2",
+        "express": "^4.19.2",
+        "multer": "^1.4.5-lts.1"
       },
       "devDependencies": {
         "@babel/core": "^7.22.9",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "gulp-webp": "^4.0.1",
     "imagemin-webp": "^8.0.0",
     "p-map": "^6.0.0",
-    "sharp": "^0.32.2"
+    "sharp": "^0.32.2",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Optimiseur d'images</title>
+<style>
+body {font-family: Arial, sans-serif; margin: 20px;}
+#drop-zone {border: 2px dashed #ccc; padding: 40px; text-align:center;}
+#images {margin-top:20px;}
+.image-item {margin:10px 0;}
+</style>
+</head>
+<body>
+<h1>Optimiseur d'images</h1>
+<div id="drop-zone">Glissez vos images ici ou cliquez pour sélectionner</div>
+<form id="options">
+<label for="format">Format :</label>
+<select id="format">
+  <option value="jpg">JPG</option>
+  <option value="webp">WebP</option>
+</select>
+<label for="width">Largeur :</label>
+<input type="number" id="width" placeholder="ex: 800">
+<label for="height">Hauteur :</label>
+<input type="number" id="height" placeholder="ex: 600">
+<button id="upload-btn" type="button">Optimiser</button>
+</form>
+<div id="images"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,62 @@
+const dropZone = document.getElementById('drop-zone');
+const uploadBtn = document.getElementById('upload-btn');
+const imagesDiv = document.getElementById('images');
+let files = [];
+
+function preview(data) {
+  data.forEach(item => {
+    const div = document.createElement('div');
+    div.className = 'image-item';
+    const link = document.createElement('a');
+    link.href = item.url;
+    link.download = item.name;
+    link.textContent = 'Télécharger ' + item.name;
+    const img = document.createElement('img');
+    img.src = item.url;
+    img.style.maxWidth = '200px';
+    div.appendChild(img);
+    div.appendChild(document.createElement('br'));
+    div.appendChild(link);
+    imagesDiv.appendChild(div);
+  });
+}
+
+function send() {
+  if (!files.length) return;
+  const format = document.getElementById('format').value;
+  const width = document.getElementById('width').value;
+  const height = document.getElementById('height').value;
+  const formData = new FormData();
+  files.forEach(f => formData.append('images', f));
+  formData.append('format', format);
+  if (width) formData.append('width', width);
+  if (height) formData.append('height', height);
+  fetch('/upload', {method: 'POST', body: formData})
+    .then(r => r.json())
+    .then(data => {
+      preview(data);
+      files = [];
+    })
+    .catch(err => console.error(err));
+}
+
+dropZone.addEventListener('dragover', e => {
+  e.preventDefault();
+});
+
+dropZone.addEventListener('drop', e => {
+  e.preventDefault();
+  files = Array.from(e.dataTransfer.files);
+});
+
+dropZone.addEventListener('click', () => {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.multiple = true;
+  input.onchange = e => {
+    files = Array.from(e.target.files);
+  };
+  input.click();
+});
+
+uploadBtn.addEventListener('click', send);

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,41 @@
+import express from 'express';
+import multer from 'multer';
+import sharp from 'sharp';
+import fs from 'fs';
+import path from 'path';
+
+const app = express();
+const upload = multer({ dest: 'uploads/' });
+const outputDir = 'public/output';
+
+if (!fs.existsSync('uploads')) fs.mkdirSync('uploads');
+if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
+
+app.use(express.static('public'));
+
+app.post('/upload', upload.array('images'), async (req, res) => {
+  const format = req.body.format || 'jpg';
+  const width = parseInt(req.body.width) || null;
+  const height = parseInt(req.body.height) || null;
+
+  const results = [];
+  for (const file of req.files) {
+    const name = path.parse(file.originalname).name + '.' + format;
+    const outputPath = path.join(outputDir, name);
+    let image = sharp(file.path);
+    if (width || height) image = image.resize(width || null, height || null);
+    if (format === 'webp') {
+      await image.toFormat('webp').toFile(outputPath);
+    } else {
+      await image.toFormat('jpeg').toFile(outputPath);
+    }
+    fs.unlinkSync(file.path);
+    results.push({ name, url: '/output/' + name });
+  }
+  res.json(results);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server started on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- remove `public` from `.gitignore`
- include express and multer dependencies
- add simple Express server handling image upload/conversion
- provide a minimal drag&drop web interface
- document how to start the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eb5a27df483239687f2bc84874b37